### PR TITLE
Add support for arbitrary forDesignTime method

### DIFF
--- a/lib/showcase_generator.dart
+++ b/lib/showcase_generator.dart
@@ -62,10 +62,7 @@ class _ShowcaseGenerator extends Generator {
     }, orElse: () => null);
     final bool hasAnyRequiredParameter = _firstRequiredParameter != null;
 
-    final ConstructorElement forDesignTime = element.constructors.singleWhere(
-      (ConstructorElement c) => c.name == 'forDesignTime',
-      orElse: () => null,
-    );
+    final MethodElement forDesignTime = element.getMethod('forDesignTime');
     final bool isForDesignTimeDefined = forDesignTime != null;
 
     if (hasAnyRequiredParameter && !isForDesignTimeDefined) {
@@ -86,6 +83,10 @@ See https://github.com/flutter/flutter-intellij/wiki/Using-live-preview
     final double boundaryHeight =
         annotatedElement.annotation.peek('height').doubleValue;
 
+    final showcase = forDesignTime.returnType.name.contains("List")
+        ? "showcaseWidgets($constructor(), size: const Size($boundaryWidth, $boundaryHeight));"
+        : "showcaseWidgets([$constructor()], size: const Size($boundaryWidth, $boundaryHeight));";
+
     buffer.write('''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
@@ -98,7 +99,7 @@ Future<void> main() async {
   await loadFonts();
 
   group('Showcase ${element.name}', () {
-    showcaseWidgets([$constructor()], size: const Size($boundaryWidth, $boundaryHeight));
+    $showcase
   });
 }
 ''');


### PR DESCRIPTION
This adds support for custom `forDesignTime` methods that produce either a single or a `List` of widgets for rendering.

**Example:**

```dart
@Showcased(width: 104.0, height: 104.0)
class ActionButton extends StatelessWidget {
  const ActionButton({Key key, this.params}) : super(key: key);

  static List<Widget> forDesignTime() {
    return [
      ActionButton(params: oneSample),
      ActionButton(params: otherSample),
      ActionButton(params: yetAnotherSample)
    ];
  }
...
```
This would produce 3 separate screenshots under the same showcase